### PR TITLE
change BaseClass test class to run as a MockitonJunitRunner, instead …

### DIFF
--- a/complete/contract-rest-service/src/test/java/hello/BaseClass.java
+++ b/complete/contract-rest-service/src/test/java/hello/BaseClass.java
@@ -2,21 +2,18 @@ package hello;
 
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest(classes = ContractRestServiceApplication.class)
+@RunWith(MockitoJUnitRunner.class)
 public abstract class BaseClass {
 
-	@Autowired PersonRestController personRestController;
-
-	@MockBean PersonService personService;
+	@InjectMocks PersonRestController personRestController;
+	@Mock PersonService personService;
 
 	@Before public void setup() {
 		RestAssuredMockMvc.standaloneSetup(personRestController);
@@ -26,3 +23,4 @@ public abstract class BaseClass {
 	}
 
 }
+


### PR DESCRIPTION
BaseClass.java is modified to run it as a Mockito Junit Runner instead of starting the whole Spring application context. This will improve the performance by eliminating the spring application context bootstrap time. 